### PR TITLE
define discovery protocol

### DIFF
--- a/core/core.proto
+++ b/core/core.proto
@@ -6,15 +6,16 @@ option java_package = "io.dronecore.core";
 option java_outer_classname = "CoreProto";
 
 service CoreService {
-    rpc SubscribeDevices(SubscribeDevicesRequest) returns(stream Device) {}
+    rpc ListRunningPlugins(ListRunningPluginsRequest) returns(ListRunningPluginsResponse) {}
 }
 
-message UUID {
-    uint64 value = 1;
+message ListRunningPluginsRequest {}
+message ListRunningPluginsResponse {
+    repeated PluginInfo = 1;
 }
 
-message SubscribeDevicesRequest {}
-
-message Device {
-    UUID uuid = 1;
+message PluginInfo {
+    string name = 1;
+    string address = 2;
+    int32 port = 3;
 }

--- a/discovery/discovery.proto
+++ b/discovery/discovery.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package dronecore.rpc.discovery;
+
+option java_package = "io.dronecore.discovery";
+option java_outer_classname = "DiscoveryProto";
+
+service DiscoveryService {
+    rpc SubscribeDiscoveredDevices(SubscribeDiscoveredDevicesRequest) returns(stream DiscoveredDeviceResponse) {}
+}
+
+message SubscribeDiscoveredDevicesRequest {}
+message DiscoveredDeviceResponse {
+    DeviceInfo device_info = 1;
+}
+
+message DeviceInfo {
+    uint64 uuid = 1;
+    string address = 2;
+    int32 port = 3;
+    bool is_core_instance = 4;
+}


### PR DESCRIPTION
This is trying to define the client interface for multi-devices (feel free to suggest other ways if you find this unintuitive!).

* A client fetches the list of known devices through a "discovery" module.
* If a client doesn't know any discovery module, it can start one on its own.
* The discovery module listens for both dronecore instances and mavlink instances (for the latter, the client might want to start a dronecore instance).
* For each discovered device, the module gives a UUID and an address, and says if it is a dronecore instance or not (in which case it is a mavlink instance).
* When a client knows the address of the dronecore instance it wants to use, it can lists the corresponding plugins and get, for each of them, the address of the corresponding grpc server.

In the first iteration, we will not have any discovery module (so we will always assume the client knows the address of the dronecore instance) and the plugins will run behind the same grpc server as the core. But at least the API will be ready for the future.

Fixes #1.