### PR TITLE
download request should have a mission_result

### DIFF
--- a/mission/mission.proto
+++ b/mission/mission.proto
@@ -26,7 +26,8 @@ message UploadMissionResponse {
 
 message DownloadMissionRequest {}
 message DownloadMissionResponse {
-    Mission mission = 1;
+    MissionResult mission_result = 1;
+    Mission mission = 2;
 }
 
 message StartMissionRequest {}


### PR DESCRIPTION
I missed it when creating the file, but it is actually there in the `mission.h` interface.