### PR TITLE
Parse return type of methods

### DIFF
--- a/pb_plugins/dcsdkgen/autogen.py
+++ b/pb_plugins/dcsdkgen/autogen.py
@@ -30,14 +30,17 @@ class AutoGen(object):
                                              proto_file.message_type,
                                              template_env)
 
+            requests = Struct.collect_requests(proto_file.package,
+                                               proto_file.message_type)
+
             responses = Struct.collect_responses(proto_file.package,
-                                                 proto_file.message_type,
-                                                 template_env)
+                                                 proto_file.message_type)
 
             methods = Method.collect_methods(plugin_name,
                                              proto_file.package,
                                              proto_file.service[0].method,
                                              structs,
+                                             requests,
                                              responses,
                                              template_env)
 

--- a/pb_plugins/dcsdkgen/methods.py
+++ b/pb_plugins/dcsdkgen/methods.py
@@ -11,7 +11,13 @@ from .utils import (decapitalize,
 class Method(object):
     """ Method """
 
-    def __init__(self, plugin_name, package, pb_method, requests, responses):
+    def __init__(
+            self,
+            plugin_name,
+            package,
+            pb_method,
+            requests,
+            responses):
         self._plugin_name = plugin_name
         self._package = package
         self._name = decapitalize(pb_method.name)
@@ -28,7 +34,8 @@ class Method(object):
 
         return_params = list(filter_out_result(response.field))
         if len(return_params) > 1:
-            raise Exception("Responses cannot have more than 1 return parameter (and an optional '*Result')!\nError in {}".format(method_output))
+            raise Exception(
+                "Responses cannot have more than 1 return parameter (and an optional '*Result')!\nError in {}".format(method_output))
 
         if len(return_params) == 1:
             self._return_type = extract_string_type(return_params[0])
@@ -82,7 +89,14 @@ class CompletableMethod(Method):
     """ A completable method doesn't return any value,
     but either succeeds or fails """
 
-    def __init__(self, plugin_name, package, template_env, pb_method, requests, responses):
+    def __init__(
+            self,
+            plugin_name,
+            package,
+            template_env,
+            pb_method,
+            requests,
+            responses):
         super().__init__(plugin_name, package, pb_method, requests, responses)
         self._template = template_env.get_template("method_completable.j2")
 
@@ -96,7 +110,14 @@ class CompletableMethod(Method):
 class SingleMethod(Method):
     """ A single method returns a value once """
 
-    def __init__(self, plugin_name, package, template_env, pb_method, requests, responses):
+    def __init__(
+            self,
+            plugin_name,
+            package,
+            template_env,
+            pb_method,
+            requests,
+            responses):
         super().__init__(plugin_name, package, pb_method, requests, responses)
         self._template = template_env.get_template("method_single.j2")
 
@@ -111,7 +132,14 @@ class SingleMethod(Method):
 class ObservableMethod(Method):
     """ An observable method emits a stream of values """
 
-    def __init__(self, plugin_name, package, template_env, pb_method, requests, responses):
+    def __init__(
+            self,
+            plugin_name,
+            package,
+            template_env,
+            pb_method,
+            requests,
+            responses):
         super().__init__(plugin_name, package, pb_method, requests, responses)
         self._name = decapitalize(pb_method.name) + "Observable"
         self._capitalized_name = pb_method.name + "Observable"
@@ -126,4 +154,3 @@ class ObservableMethod(Method):
                                      plugin_name=self._plugin_name,
                                      request_name=self._request_name,
                                      request_rpc_type=self._request_rpc_type)
-

--- a/pb_plugins/dcsdkgen/methods.py
+++ b/pb_plugins/dcsdkgen/methods.py
@@ -2,6 +2,8 @@
 
 
 from .utils import (decapitalize,
+                    extract_string_type,
+                    filter_out_result,
                     is_completable,
                     is_observable)
 
@@ -9,14 +11,28 @@ from .utils import (decapitalize,
 class Method(object):
     """ Method """
 
-    def __init__(self, plugin_name, package, pb_method):
+    def __init__(self, plugin_name, package, pb_method, requests, responses):
         self._plugin_name = plugin_name
         self._package = package
-        self._name = pb_method.name
+        self._name = decapitalize(pb_method.name)
         self._request_rpc_type = (package.title().replace(".", "_")
                                   + "_"
                                   + pb_method.name
                                   + "Request")
+        self.extract_return_type_and_name(pb_method, responses)
+
+    def extract_return_type_and_name(self, pb_method, responses):
+        method_output = pb_method.output_type.split(".")[-1]
+        response = responses[method_output]
+        nb_fields = len(response.field)
+
+        return_params = list(filter_out_result(response.field))
+        if len(return_params) > 1:
+            raise Exception("Responses cannot have more than 1 return parameter (and an optional '*Result')!\nError in {}".format(method_output))
+
+        if len(return_params) == 1:
+            self._return_type = extract_string_type(return_params[0])
+            self._return_name = return_params[0].json_name
 
     @staticmethod
     def collect_methods(
@@ -24,6 +40,7 @@ class Method(object):
             package,
             methods,
             structs,
+            requests,
             responses,
             template_env):
         """ Collects all methods for the plugin """
@@ -34,20 +51,26 @@ class Method(object):
                 _methods[method.name] = CompletableMethod(plugin_name,
                                                           package,
                                                           template_env,
-                                                          method)
+                                                          method,
+                                                          requests,
+                                                          responses)
 
             # Check if method is observable
             elif (is_observable(method)):
                 _methods[method.name] = ObservableMethod(plugin_name,
                                                          package,
                                                          template_env,
-                                                         method)
+                                                         method,
+                                                         requests,
+                                                         responses)
 
             else:
                 _methods[method.name] = SingleMethod(plugin_name,
                                                      package,
                                                      template_env,
-                                                     method)
+                                                     method,
+                                                     requests,
+                                                     responses)
 
         return _methods
 
@@ -59,8 +82,8 @@ class CompletableMethod(Method):
     """ A completable method doesn't return any value,
     but either succeeds or fails """
 
-    def __init__(self, plugin_name, package, template_env, pb_method):
-        super().__init__(plugin_name, package, pb_method)
+    def __init__(self, plugin_name, package, template_env, pb_method, requests, responses):
+        super().__init__(plugin_name, package, pb_method, requests, responses)
         self._template = template_env.get_template("method_completable.j2")
 
     def __repr__(self):
@@ -73,17 +96,14 @@ class CompletableMethod(Method):
 class SingleMethod(Method):
     """ A single method returns a value once """
 
-    def __init__(self, plugin_name, package, template_env, pb_method):
-        super().__init__(plugin_name, package, pb_method)
+    def __init__(self, plugin_name, package, template_env, pb_method, requests, responses):
+        super().__init__(plugin_name, package, pb_method, requests, responses)
         self._template = template_env.get_template("method_single.j2")
-        self.extract_field_type_and_name(pb_method)
-
-    def extract_field_type_and_name(self, pb_method):
-        self._type = "Float"  # TODO
 
     def __repr__(self):
         return self._template.render(name=self._name,
-                                     elem_type=self._type,
+                                     return_type=self._return_type,
+                                     return_name=self._return_name,
                                      plugin_name=self._plugin_name,
                                      request_rpc_type=self._request_rpc_type)
 
@@ -91,21 +111,18 @@ class SingleMethod(Method):
 class ObservableMethod(Method):
     """ An observable method emits a stream of values """
 
-    def __init__(self, plugin_name, package, template_env, pb_method):
-        super().__init__(plugin_name, package, pb_method)
+    def __init__(self, plugin_name, package, template_env, pb_method, requests, responses):
+        super().__init__(plugin_name, package, pb_method, requests, responses)
         self._name = decapitalize(pb_method.name) + "Observable"
         self._capitalized_name = pb_method.name + "Observable"
         self._request_name = self._name + "Request"
         self._template = template_env.get_template("method_observable.j2")
-        self.extract_field_type_and_name(pb_method)
-
-    def extract_field_type_and_name(self, pb_method):
-        self._type = "Float"  # TODO
 
     def __repr__(self):
         return self._template.render(name=self._name,
                                      capitalized_name=self._capitalized_name,
-                                     elem_type=self._type,
+                                     return_type=self._return_type,
+                                     return_name=self._return_name,
                                      plugin_name=self._plugin_name,
                                      request_name=self._request_name,
                                      request_rpc_type=self._request_rpc_type)

--- a/pb_plugins/dcsdkgen/struct.py
+++ b/pb_plugins/dcsdkgen/struct.py
@@ -2,6 +2,7 @@
 
 
 from .utils import (extract_string_type,
+                    is_request,
                     is_response,
                     is_struct)
 
@@ -36,7 +37,17 @@ class Struct(object):
         return _structs
 
     @staticmethod
-    def collect_responses(package, structs, template_env):
+    def collect_requests(package, structs):
+        _requests = {}
+
+        for struct in structs:
+            if is_request(struct):
+                _requests[struct.name] = struct
+
+        return _requests
+
+    @staticmethod
+    def collect_responses(package, structs):
         _responses = {}
 
         for struct in structs:

--- a/pb_plugins/dcsdkgen/utils.py
+++ b/pb_plugins/dcsdkgen/utils.py
@@ -46,16 +46,16 @@ def is_struct(struct):
 def extract_string_type(field):
     """ Extracts the string types """
     types = {
-            1: "Double",
-            2: "Float",
-            4: "UInt64",
-            5: "Int",
-            8: "Bool",
-            9: "String",
-            13: "UInt32",
-            11: str(field.type_name.split(".")[-1]),
-            14: str(field.type_name.split(".")[-1])
-            }
+        1: "Double",
+        2: "Float",
+        4: "UInt64",
+        5: "Int",
+        8: "Bool",
+        9: "String",
+        13: "UInt32",
+        11: str(field.type_name.split(".")[-1]),
+        14: str(field.type_name.split(".")[-1])
+    }
 
     if (field.type in types):
         return types[field.type]
@@ -66,7 +66,13 @@ def extract_string_type(field):
 def filter_out_result(fields):
     """ Filters out the result fields (".*Result$") """
     for field in fields:
-        if not extract_string_type(field).endswith("Result"): yield field
+        if not is_result(field):
+            yield field
+
+
+def is_result(field):
+    """ Check if the field is a *Result """
+    return extract_string_type(field).endswith("Result")
 
 
 def decapitalize(s):
@@ -80,10 +86,10 @@ def jinja_indent(_in_str, level):
     _in_str = str(_in_str)
 
     return "\n".join(
-            ["" if len(line) == 0 else
-             level * "    " + line
-             for line in _in_str.split("\n")]
-            )
+        ["" if len(line) == 0 else
+         level * "    " + line
+         for line in _in_str.split("\n")]
+    )
 
 
 def letter_case_to_delimiter(_str_in):
@@ -100,7 +106,7 @@ def get_template_env(_searchpath):
 
     # Register some functions we need to access in the template
     _template_env.globals.update(
-            letter_case_to_delimiter=letter_case_to_delimiter,
-            indent=jinja_indent)
+        letter_case_to_delimiter=letter_case_to_delimiter,
+        indent=jinja_indent)
 
     return _template_env

--- a/pb_plugins/dcsdkgen/utils.py
+++ b/pb_plugins/dcsdkgen/utils.py
@@ -14,6 +14,9 @@ def is_completable(method, responses):
             method_response.field[0].type_name.endswith("Result")):
         return True
 
+    if (0 == len(method_response.field)):
+        return True
+
     return False
 
 

--- a/pb_plugins/dcsdkgen/utils.py
+++ b/pb_plugins/dcsdkgen/utils.py
@@ -22,6 +22,11 @@ def is_observable(method):
     return method.server_streaming
 
 
+def is_request(struct):
+    """ Checks if a name ends with request """
+    return struct.name.endswith("Request")
+
+
 def is_response(struct):
     """ Checks if a name ends with response """
     return struct.name.endswith("Response")
@@ -53,6 +58,12 @@ def extract_string_type(field):
         return types[field.type]
     else:
         return "UNKNOWN_TYPE"
+
+
+def filter_out_result(fields):
+    """ Filters out the result fields (".*Result$") """
+    for field in fields:
+        if not extract_string_type(field).endswith("Result"): yield field
 
 
 def decapitalize(s):

--- a/pb_plugins/templates/swift/method_observable.j2
+++ b/pb_plugins/templates/swift/method_observable.j2
@@ -1,6 +1,6 @@
-public lazy var {{ name }}: Observable<{{ elem_type }}> = create{{ capitalized_name }}()
+public lazy var {{ name }}: Observable<{{ return_type }}> = create{{ capitalized_name }}()
 
-private func create{{ name }}() -> Observable<{{ elem_type }}> {
+private func create{{ name }}() -> Observable<{{ return_type }}> {
     return Observable.create { observer in
         let {{ request_name }} = {{ request_rpc_type }}()
 

--- a/pb_plugins/templates/swift/method_single.j2
+++ b/pb_plugins/templates/swift/method_single.j2
@@ -1,10 +1,10 @@
-public func {{ name }}() -> Single<{{ elem_type }}> {
-    return Single<{{ elem_type }}>.create { single in
+public func {{ name }}() -> Single<{{ return_type }}> {
+    return Single<{{ return_type }}>.create { single in
         let {{ name }}Request = {{ request_rpc_type }}()
 
         do {
             let {{ name }}Response = try self.service.{{ name.lower() }}({{ name }}Request)
-            single(.success({{ name }}Response.BLAH))
+            single(.success({{ name }}Response.{{ return_name }}))
         } catch {
             single(.error(error))
         }

--- a/protos/mission/mission.proto
+++ b/protos/mission/mission.proto
@@ -64,8 +64,7 @@ message IsMissionFinishedResponse {
 
 message SubscribeMissionProgressRequest {}
 message MissionProgressResponse {
-    int32 current_item_index = 1;
-    int32 mission_count = 2;
+    MissionProgress mission_progress = 1;
 }
 
 message Mission {
@@ -90,6 +89,11 @@ message MissionItem {
         START_VIDEO = 4;
         STOP_VIDEO = 5;
     }
+}
+
+message MissionProgress {
+    int32 current_item_index = 1;
+    int32 mission_count = 2;
 }
 
 message MissionResult {


### PR DESCRIPTION
Parsing the return type of methods (single, observable) and passing it to the templates.

For generation purpose, `*Response` messages can now have a `Result` type (e.g. `MissionResult`, `ActionResult`, ...) and maximum one parameter (which may be a tuple). 