### PR TITLE
Rename droncore to dronecode_sdk

### DIFF
--- a/action/action.proto
+++ b/action/action.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package dronecore.rpc.action;
+package dronecode_sdk.rpc.action;
 
-option java_package = "io.dronecore.action";
+option java_package = "io.dronecode_sdk.action";
 option java_outer_classname = "ActionProto";
 
 service ActionService {

--- a/camera/camera.proto
+++ b/camera/camera.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package dronecore.rpc.camera;
+package dronecode_sdk.rpc.camera;
 
-option java_package = "io.dronecore.camera";
+option java_package = "io.dronecode_sdk.camera";
 option java_outer_classname = "CameraProto";
 
 service CameraService {

--- a/core/core.proto
+++ b/core/core.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package dronecore.rpc.core;
+package dronecode_sdk.rpc.core;
 
-option java_package = "io.dronecore.core";
+option java_package = "io.dronecode_sdk.core";
 option java_outer_classname = "CoreProto";
 
 service CoreService {

--- a/discovery/discovery.proto
+++ b/discovery/discovery.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package dronecore.rpc.discovery;
+package dronecode_sdk.rpc.discovery;
 
-option java_package = "io.dronecore.discovery";
+option java_package = "io.dronecode_sdk.discovery";
 option java_outer_classname = "DiscoveryProto";
 
 service DiscoveryService {

--- a/gimbal/gimbal.proto
+++ b/gimbal/gimbal.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package dronecore.rpc.gimbal;
+package dronecode_sdk.rpc.gimbal;
 
-option java_package = "io.dronecore.gimbal";
+option java_package = "io.dronecode_sdk.gimbal";
 option java_outer_classname = "GimbalProto";
 
 service GimbalService {

--- a/mission/mission.proto
+++ b/mission/mission.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package dronecore.rpc.mission;
+package dronecode_sdk.rpc.mission;
 
-option java_package = "io.dronecore.mission";
+option java_package = "io.dronecode_sdk.mission";
 option java_outer_classname = "MissionProto";
 
 service MissionService {

--- a/telemetry/telemetry.proto
+++ b/telemetry/telemetry.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package dronecore.rpc.telemetry;
+package dronecode_sdk.rpc.telemetry;
 
-option java_package = "io.dronecore.telemetry";
+option java_package = "io.dronecode_sdk.telemetry";
 option java_outer_classname = "TelemetryProto";
 
 service TelemetryService {


### PR DESCRIPTION
We're transitioning from DroneCore to the Dronecode SDK, and this is part of the rename.