### PR TITLE
Handle complex return types

### DIFF
--- a/pb_plugins/dcsdkgen/methods.py
+++ b/pb_plugins/dcsdkgen/methods.py
@@ -3,6 +3,7 @@
 
 from .utils import (decapitalize,
                     extract_string_type,
+                    is_primitive_type,
                     filter_out_result,
                     is_completable,
                     is_observable)
@@ -39,6 +40,7 @@ class Method(object):
 
         if len(return_params) == 1:
             self._return_type = extract_string_type(return_params[0])
+            self._is_return_type_primitive = is_primitive_type(return_params[0])
             self._return_name = return_params[0].json_name
 
     @staticmethod

--- a/pb_plugins/dcsdkgen/utils.py
+++ b/pb_plugins/dcsdkgen/utils.py
@@ -62,6 +62,10 @@ def extract_string_type(field):
     else:
         return "UNKNOWN_TYPE"
 
+def is_primitive_type(field):
+    """ Check if the field type is primitive (e.g. bool,
+    float) or not (e.g message, enum) """
+    return (not field.type in { 11, 14 })
 
 def filter_out_result(fields):
     """ Filters out the result fields (".*Result$") """

--- a/pb_plugins/templates/swift/file.j2
+++ b/pb_plugins/templates/swift/file.j2
@@ -3,15 +3,15 @@ import gRPC
 import RxSwift
 
 public class {{ plugin_name }} {
-    {%- for enum in enums %}
-    {{ indent(enum, 1) }}
-    {%- endfor %}
+{%- for enum in enums %}
+{{ indent(enum, 1) }}
+{%- endfor %}
 
-    {%- for struct in structs %}
-    {{ indent(struct, 1) }}
-    {%- endfor %}
+{%- for struct in structs %}
+{{ indent(struct, 1) }}
+{%- endfor %}
 
-    {%- for method in methods %}
-    {{ indent(method, 1) }}
-    {%- endfor %}
+{%- for method in methods %}
+{{ indent(method, 1) }}
+{%- endfor %}
 }

--- a/pb_plugins/templates/swift/method_observable.j2
+++ b/pb_plugins/templates/swift/method_observable.j2
@@ -7,9 +7,14 @@ private func create{{ name }}() -> Observable<{{ return_type }}> {
         do {
             let call = try self.service.subscribe{{ name.lower() }}({{ request_name }}, completion: nil)
             while let response = try? call.receive() {
-                let position = Position(latitudeDeg: response.position.latitudeDeg, longitudeDeg: response.position.longitudeDeg, absoluteAltitudeM: response.position.absoluteAltitudeM, relativeAltitudeM: response.position.relativeAltitudeM)
 
-                observer.onNext(position)
+                {% if is_return_type_primitive -%}
+                   let {{ return_name }} = response.{{ return_name }}
+                {% else -%}
+                    let {{ return_name }} = {{ return_type }}.translateFromRPC(response.{{ return_name }})
+                {%- endif %}
+
+                observer.onNext({{ return_name }})
             }
         } catch {
             observer.onError("Failed to subscribe to {{ name }} stream")

--- a/pb_plugins/templates/swift/method_single.j2
+++ b/pb_plugins/templates/swift/method_single.j2
@@ -3,8 +3,14 @@ public func {{ name }}() -> Single<{{ return_type }}> {
         let {{ name }}Request = {{ request_rpc_type }}()
 
         do {
-            let {{ name }}Response = try self.service.{{ name.lower() }}({{ name }}Request)
-            single(.success({{ name }}Response.{{ return_name }}))
+            let response = try self.service.{{ name.lower() }}({{ name }}Request)
+            {% if is_return_type_primitive -%}
+               let {{ return_name }} = response.{{ return_name }}
+            {% else -%}
+                let {{ return_name }} = {{ return_type }}.translateFromRPC(response.{{ return_name }})
+            {%- endif %}
+
+            single(.success({{ return_name }}))
         } catch {
             single(.error(error))
         }


### PR DESCRIPTION
Check if the return type is a primitive type or not. If not, the message/enum needs to be translated.

@xvzf